### PR TITLE
Make choosing an initial weight/waist circumference faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 ### Removed
 - None.
 ### Fixed
-- None.
+- Choosing an initial weight or waist circumference is much faster now (10x / 2x) by just increasing the step size on initial value choosing.  
+  PR: [#2](https://github.com/Flinesoft/FitnessTracker-Android/pull/2) | Author: [Cihat Gündüz](https://github.com/Jeehut)  
 ### Security
 - None.
 

--- a/app/src/main/kotlin/com/flinesoft/fitnesstracker/globals/extensions/FragmentExt.kt
+++ b/app/src/main/kotlin/com/flinesoft/fitnesstracker/globals/extensions/FragmentExt.kt
@@ -9,6 +9,8 @@ import android.widget.NumberPicker
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.AndroidViewModel
 import com.flinesoft.fitnesstracker.R
+import com.flinesoft.fitnesstracker.globals.DEFAULT_INPUT_VALUE_WAIST_CIRCUMFERENCE_IN_CENTIMETERS
+import com.flinesoft.fitnesstracker.globals.DEFAULT_INPUT_VALUE_WEIGHT_IN_KILOGRAMS
 import com.flinesoft.fitnesstracker.globals.HUMAN_WAIST_CIRCUMFERENCE_RANGE_IN_CENTIMETERS
 import com.flinesoft.fitnesstracker.globals.HUMAN_WEIGHT_RANGE_IN_KILOGRAMS
 import com.flinesoft.fitnesstracker.persistence.FitnessTrackerDatabase
@@ -76,23 +78,23 @@ fun Fragment.showNumberPickerDialog(
         .show()
 }
 
-fun Fragment.showWaistCircumferencePickerDialog(title: String, value: Double, valueChooseAction: (Double) -> Unit) {
+fun Fragment.showWaistCircumferencePickerDialog(title: String, value: Double?, valueChooseAction: (Double) -> Unit) {
     showNumberPickerDialog(
         title = title,
-        value = value,
+        value = value ?: DEFAULT_INPUT_VALUE_WAIST_CIRCUMFERENCE_IN_CENTIMETERS,
         range = HUMAN_WAIST_CIRCUMFERENCE_RANGE_IN_CENTIMETERS,
-        stepSize = 0.5,
+        stepSize = if (value != null) 0.5 else 1.0,
         formatToString = { MeasureFormatExt.short().doubleToString(it, MeasureUnit.CENTIMETER) },
         valueChooseAction = valueChooseAction
     )
 }
 
-fun Fragment.showWeightPickerDialog(title: String, value: Double, valueChooseAction: (Double) -> Unit) {
+fun Fragment.showWeightPickerDialog(title: String, value: Double?, valueChooseAction: (Double) -> Unit) {
     showNumberPickerDialog(
         title = title,
-        value = value,
+        value = value ?: DEFAULT_INPUT_VALUE_WEIGHT_IN_KILOGRAMS,
         range = HUMAN_WEIGHT_RANGE_IN_KILOGRAMS,
-        stepSize = 0.1,
+        stepSize = if (value != null) 0.1 else 1.0,
         formatToString = { MeasureFormatExt.short().doubleToString(it, MeasureUnit.KILOGRAM) },
         valueChooseAction = valueChooseAction
     )

--- a/app/src/main/kotlin/com/flinesoft/fitnesstracker/ui/statistics/StatisticsFragment.kt
+++ b/app/src/main/kotlin/com/flinesoft/fitnesstracker/ui/statistics/StatisticsFragment.kt
@@ -17,8 +17,6 @@ import com.flinesoft.fitnesstracker.R
 import com.flinesoft.fitnesstracker.databinding.StatisticsFragmentBinding
 import com.flinesoft.fitnesstracker.globals.APP_FEEDBACK_FORUM_URL
 import com.flinesoft.fitnesstracker.globals.AppPreferences
-import com.flinesoft.fitnesstracker.globals.DEFAULT_INPUT_VALUE_WAIST_CIRCUMFERENCE_IN_CENTIMETERS
-import com.flinesoft.fitnesstracker.globals.DEFAULT_INPUT_VALUE_WEIGHT_IN_KILOGRAMS
 import com.flinesoft.fitnesstracker.globals.DEFAULT_MODAL_PRESENTATION_DELAY
 import com.flinesoft.fitnesstracker.globals.extensions.database
 import com.flinesoft.fitnesstracker.globals.extensions.showWaistCircumferencePickerDialog
@@ -137,7 +135,7 @@ class StatisticsFragment : Fragment() {
     private fun showNewWaistCircumferenceForm() {
         showWaistCircumferencePickerDialog(
             title = getString(R.string.statistics_speed_dial_waist_circumference),
-            value = viewModel.latestWaistCircumferenceMeasurement()?.value ?: DEFAULT_INPUT_VALUE_WAIST_CIRCUMFERENCE_IN_CENTIMETERS,
+            value = viewModel.latestWaistCircumferenceMeasurement()?.value,
             valueChooseAction = {
                 saveNewWaistCircumference(it)
                 view?.snack(R.string.global_info_saved_successfully)
@@ -148,7 +146,7 @@ class StatisticsFragment : Fragment() {
     private fun showNewWeightForm() {
         showWeightPickerDialog(
             title = getString(R.string.statistics_speed_dial_weight),
-            value = viewModel.latestWeightMeasurement()?.value ?: DEFAULT_INPUT_VALUE_WEIGHT_IN_KILOGRAMS,
+            value = viewModel.latestWeightMeasurement()?.value,
             valueChooseAction = {
                 saveNewWeight(it)
                 view?.snack(R.string.global_info_saved_successfully)


### PR DESCRIPTION
Multiple test users have reported that on first choosing of the weight or waist circumference it could take quite a while and a lot of scrolling until the correct values were reached. That's not a problem anymore once the first value is chosen as the relative change is much smaller than the first value choosing.

This PR fixes the issue by simply making the stepping for the initial value higher for both.